### PR TITLE
build(.npmignore): Remove coverage and /.nyc_output from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,8 @@
 /src
 /node_modules
 /test
+/.nyc_output
+/coverage
 
 # ignore typescript files
 *.ts


### PR DESCRIPTION
closes #25