### PR TITLE
feat(bin/nglb): Add version option

### DIFF
--- a/src/bin/nglb.ts
+++ b/src/bin/nglb.ts
@@ -5,12 +5,25 @@ import { optionsValues } from './options.values';
 import { AngularLibraryBuilder } from '../core/angular-library-builder';
 
 const argv = yargs
-  .usage('Usage: $0 [options]')
-  .example('Example: $0 --rootDir src/lib --outDir dist',
-    '[root directory is src/lib and the output directory is dist]')
-  .options(optionsValues)
+  // help
   .help('help')
   .alias('help', 'h')
+
+  // version
+  .version(() => require('../package.json').version)
+  .alias('version', 'v')
+
+  // usage
+  .usage('Usage: $0 [options]')
+  .example('Example: $0 --rootDir src/lib --outDir dist', '[root directory is src/lib and the output directory is dist]')
+
+  // options
+  .options(optionsValues)
+
+  // only accept known parameters
+  .strict()
+
+  // epilog, aka, footer of the helper command
   .epilog('Angular (2+) Library Builder')
   .argv;
 


### PR DESCRIPTION
Add version option to this package. Now when type "nglb -v" this package will output the currently
installed version. Add strict to yargs, in order to only accept valid options.

closes #36